### PR TITLE
Fix regex bug

### DIFF
--- a/group.go
+++ b/group.go
@@ -7,14 +7,28 @@ type Group struct {
 	middleware []Middleware
 }
 
-func NewGroup(routes ...*Route) *Group {
-	return &Group{
-		routes: routes,
+func (g *Group) calculateRouteRegexs() {
+	for _, r := range g.routes {
+		r.regex = r.calculateRouteRegex()
 	}
+}
+
+func NewGroup(routes ...*Route) *Group {
+	g := &Group{}
+
+	for _, r := range routes {
+		r.group = g
+		g.calculateRouteRegexs()
+	}
+
+	g.routes = routes
+
+	return g
 }
 
 func (g *Group) Prefix(path string) *Group {
 	g.prefix = path
+	g.calculateRouteRegexs()
 	return g
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -71,6 +71,20 @@ func TestResponseCodes(t *testing.T) {
 	}
 }
 
+func TestEmptyRouteIsNotCatchall(t *testing.T) {
+	router := router.New()
+	router.Get("/", func() string {
+		return "hello"
+	})
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp, _ := http.Get(server.URL + "/nonexistant")
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 func TestRouteDispatching(t *testing.T) {
 	router := router.New()
 	server := httptest.NewServer(router)


### PR DESCRIPTION
- The regex created did not contain a beginning caret, which meant it could be matched inadvertently by other routes.
- Fixed issue with looking up routes registered as part of a group.

This whole thing needs refactoring, but will probably do so once functionality becomes a little more stable and test coverage is increased.